### PR TITLE
Update gulp-umd Configuration to Export AutoMapperJs Namespace

### DIFF
--- a/GulpFile.js
+++ b/GulpFile.js
@@ -124,8 +124,11 @@ gulp.task('bundle-app', ['compile-app'], function () {
         .pipe(sourcemaps.init())
         .pipe(concat(config.appBundleName))
         .pipe(umd({
-            exports: function (file) {
-                return path.basename(file.path, path.extname(file.path));
+            exports: function () {
+                return 'AutoMapperJs';
+            },
+            namespace: function () {
+                return 'AutoMapperJs';
             }
         }))
         .pipe(header(config.libraryHeaderTemplate, {


### PR DESCRIPTION
Before, the UMD configuration ensured that only the `automapper` global
variable was exported. Now, the whole `AutoMapperJs` namespace is
exported. This makes things such as `Profile` and
`CamelCaseNamingConvention` available. The `automapper` variable is
still attached to `window` (or `global`), as there is code in
`AutoMapper.ts` that ensures it does.

Note that in a webpack environment, the `automapper` variable is likely
**not** placed on the `window` or `global` object, as the global `this`
object is likely not the `global` or `window. In this case, calling
`AutoMapper.getInstance()` to get the singleton is likely required.

I think there could be more work on this codebase as far as how it
handles exports and namespacing, and I think I'll have some time to look
into continuing that.

Fixes #41.